### PR TITLE
Expose local variables to dinamic libraries

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -150,6 +150,10 @@ ifeq "$(GCCMAJORGTEQ4)" "1"
 	LDFLAGS += -Wl,-z,relro,-z,now
 	# Ubuntu optimization flag
 	LDFLAGS += -Wl,--hash-style=gnu
+	# Export variables to dinamically loaded libraries;
+	# solves "Undefined symbol lua_settop" error when lua 
+	# script tries to request external library
+	LDFLAGS += -Wl,--export-dynamic
 endif # gcc >= 4.x.x
 endif # linux
 


### PR DESCRIPTION
Export variables to dinamically loaded libraries; solves "Undefined symbol lua_settop" error when lua script tries to request external library