### PR TITLE
Fix compilation with system libpt and libh323plus

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -189,7 +189,7 @@ endif
 
 # special dependency to ensure version.cxx is rebuilt each time gnugk is recompiled
 # so the proper build timestamp is included
-version.cxx: $(subst version.cxx,,$(SOURCES)) $(HEADERS) $(OH323_LIBDIR)/$(OH323_FILE) $(PT_LIBDIR)/$(PTLIB_FILE)
+version.cxx: $(subst version.cxx,,$(SOURCES)) $(HEADERS)
 	@touch $@
 
 doc:


### PR DESCRIPTION
When libpt and libh323plus are installed as system packages, PT_LIBDIR and OH323_LIBDIR do not reflect the actual location of these libraries, which makes version.cxx compilation fail due to missing dependencies. Drop these formal dependencies.

gnugk linking process is unaffected; it will succeed as long as these libraries are in default locations for the system.